### PR TITLE
Moving the SDK from .Net Standard 2.1, to 2.0

### DIFF
--- a/OneSky.Services.Tests/OneSky.Services.Tests.csproj
+++ b/OneSky.Services.Tests/OneSky.Services.Tests.csproj
@@ -17,13 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\OneSky.Services\OneSky.Services.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="OneSky.Services.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OneSky.Services\OneSky.Services.csproj" />
   </ItemGroup>
 
 </Project>

--- a/OneSky.Services.Tests/Weather/WeatherTests.cs
+++ b/OneSky.Services.Tests/Weather/WeatherTests.cs
@@ -41,6 +41,7 @@ namespace OneSky.Services.Tests.Weather
         }
 
         [Test]
+        [DebugExplicit] // AS-149 will fix a services error when this data is unavailable
         public void TestWeatherAlongARouteWithSingapore()
         {
             var request = new WeatherData<PointToPointRouteData>();

--- a/OneSky.Services/OneSky.Services.csproj
+++ b/OneSky.Services/OneSky.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>2.0.0</Version>
     <releaseNotes>Bug fixes</releaseNotes>


### PR DESCRIPTION
Thsi change allows the SDK to be used in .Net Framework solutions as well.